### PR TITLE
Fix the Serotracker logo dissapearing on page refresh on certain pages such as the map.

### DIFF
--- a/components/customs/header.tsx
+++ b/components/customs/header.tsx
@@ -63,7 +63,7 @@ export const Header = () => {
       <div className="cursor-pointer py-5 pl-2">
         <Link href={"Explore"} className="flex items-center">
           <Image
-            src={"./SerotrackerLogo.svg"}
+            src={"/SerotrackerLogo.svg"}
             alt={"Serotracker Logo"}
             width={23}
             height={23}


### PR DESCRIPTION
Resolves #16

![Screenshot006](https://github.com/PathoTracker/Pathotracker/assets/86806388/5de48be4-faa8-46b1-94f8-0ba95d9ed793)
