### PR TITLE
Antibody filter

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,7 @@
 @layer base {
   :root {
     --background: 206 28% 29%;
+    --background-hover: 206 28% 43%;
     --foreground: 0 0% 100%;
 
     --card: 0 0% 100%;

--- a/app/pathogen/arbovirus/analyze/ArboDataTable.tsx
+++ b/app/pathogen/arbovirus/analyze/ArboDataTable.tsx
@@ -10,7 +10,7 @@ export default function ArboDataTable() {
   const dataQuery = useArboData();
   const state = useContext(ArboContext);
   if(state.filteredData?.length > 0 || (dataQuery.isSuccess && dataQuery.data)) {
-    return <DataTable columns={columns} data={state.filteredData} />;
+  return <DataTable columns={columns} data={state.filteredData?.length <= 0 && !state.dataFiltered ? dataQuery.data.records : state.filteredData} />;
   } else {
     return <>Loading Data ...</>
   }

--- a/app/pathogen/arbovirus/analyze/ArboDataTable.tsx
+++ b/app/pathogen/arbovirus/analyze/ArboDataTable.tsx
@@ -10,7 +10,7 @@ export default function ArboDataTable() {
   const dataQuery = useArboData();
   const state = useContext(ArboContext);
   if(state.filteredData?.length > 0 || (dataQuery.isSuccess && dataQuery.data)) {
-  return <DataTable columns={columns} data={state.filteredData?.length > 0 ? state.filteredData : dataQuery.data.records} />;
+    return <DataTable columns={columns} data={state.filteredData} />;
   } else {
     return <>Loading Data ...</>
   }

--- a/app/pathogen/arbovirus/analyze/columns.tsx
+++ b/app/pathogen/arbovirus/analyze/columns.tsx
@@ -4,6 +4,7 @@ import { ColumnDef } from "@tanstack/table-core";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowUpDown } from "lucide-react";
+import { pathogenColors } from "../dashboard/(map)/MapAndFilters";
 
 export type Estimate = {
   age_group: string;
@@ -49,14 +50,91 @@ export const columns: ColumnDef<Estimate>[] = [
         </Button>
       );
     },
-  },
-  {
-    accessorKey: "antibodies",
-    header: "Antibodies",
+    cell: ({ row }) => {
+      const pathogen = row.getValue("pathogen");
+      if (typeof pathogen === "string") {
+        let color: string = "";
+        switch (pathogen) {
+          case "DENV":
+            color = "bg-denv";
+            break;
+          case "ZIKV":
+            color = "bg-zikv";
+            break;
+          case "CHIKV":
+            color = "bg-chikv";
+            break;
+          case "YF":
+            color = "bg-yf";
+            break;
+          case "WNV":
+            color = "bg-wnv";
+            break;
+          case "MAYV":
+            color = "bg-mayv";
+            break;
+          default:
+            color = "bg-gray-100";
+            break;
+        }
+
+        return (
+          <div className={color + " p-2 rounded-sm text-center"}>{pathogen}</div>
+        )
+
+      }
+      return "N/A";
+    }
   },
   {
     accessorKey: "seroprevalence",
     header: "Seroprevalence",
+    cell: ({ row }) => {
+      const seroprevalence = row.getValue("seroprevalence");
+      if (typeof seroprevalence === 'number') {
+        return `${(seroprevalence * 100).toFixed(1)}%`;
+      } else if (typeof seroprevalence === 'string') {
+        const seroprevalenceNumber = parseFloat(seroprevalence);
+        if (!isNaN(seroprevalenceNumber)) {
+          return `${(seroprevalenceNumber * 100).toFixed(1)}%`;
+        }
+      }
+      return 'N/A';
+    }
+  },
+  {
+    accessorKey: "antibodies",
+    header: "Antibodies",
+    cell: ({ row }) => {
+      const antibodies = row.getValue("antibodies");
+      if (Array.isArray(antibodies)) {
+        return antibodies.sort().map((antibody) => {
+          let color: string = ""
+          switch (antibody) {
+            case "IgG": 
+              color = "bg-blue-700 text-white"
+              break;
+            case "IgM": 
+              color = "bg-black text-white"
+              break;
+            case "IgAM": 
+              color = "bg-green-200"
+              break;
+            case "NAb": 
+              color = "bg-yellow-400"
+              break;
+            default:
+              color = "bg-sky-100"
+              break;
+          }
+
+          return (
+            <span className={color + " m-1 p-2 rounded-sm"} key={antibody}>{antibody}</span>
+          )
+      });
+      }
+      return 'N/A';
+    }
   },
   {
     accessorKey: "assay",
@@ -74,10 +152,10 @@ export const columns: ColumnDef<Estimate>[] = [
     accessorKey: "producer_other",
     header: "Producer Other",
   },
-  {
-    accessorKey: "same_frame_target_group",
-    header: "Same Frame Target Group",
-  },
+  // {
+  //   accessorKey: "same_frame_target_group",
+  //   header: "Same Frame Target Group",
+  // },
   // {
   //   accessorKey: "sample_end_date",
   //   header: "Sample End Date",
@@ -102,14 +180,6 @@ export const columns: ColumnDef<Estimate>[] = [
     accessorKey: "country",
     header: "Country",
   },
-  {
-    accessorKey: "latitude",
-    header: "Latitude",
-  },
-  {
-    accessorKey: "longitude",
-    header: "Longitude",
-  },
   // {
   //   accessorKey: "sample_start_date",
   //   header: "Sample Start Date",
@@ -130,8 +200,16 @@ export const columns: ColumnDef<Estimate>[] = [
     accessorKey: "age_minimum",
     header: "Age Minimum",
   },
-  // {
-  //   accessorKey: "url",
-  //   header: "URL",
-  // },
+  {
+    accessorKey: "url",
+    header: "Source",
+    cell: ({ row }) => {
+      console.log(row.getValue("url"));
+      return (
+        <Button onClick={() => window.open(row.getValue("url"))} className="w-full">
+          {new URL(row.getValue("url")).hostname}
+        </Button>
+      )
+    },
+  },
 ];

--- a/app/pathogen/arbovirus/analyze/columns.tsx
+++ b/app/pathogen/arbovirus/analyze/columns.tsx
@@ -204,7 +204,6 @@ export const columns: ColumnDef<Estimate>[] = [
     accessorKey: "url",
     header: "Source",
     cell: ({ row }) => {
-      console.log(row.getValue("url"));
       return (
         <Button onClick={() => window.open(row.getValue("url"))} className="w-full">
           {new URL(row.getValue("url")).hostname}

--- a/app/pathogen/arbovirus/analyze/nivo-vis.tsx
+++ b/app/pathogen/arbovirus/analyze/nivo-vis.tsx
@@ -143,7 +143,8 @@ export function CountOfStudiesStratifiedByAntibodyAndPathogen() {
     },
   };
 
-  const rawData = state.filteredData;
+  const dataQuery = useArboData();
+  const rawData = state.filteredData?.length <= 0 && !state.dataFiltered ? dataQuery.data?.records : state.filteredData;
 
   rawData?.forEach((d: any) => {
     const antibodies = d.antibodies as (keyof typeof data)[];
@@ -234,7 +235,8 @@ export function CountOfStudiesStratifiedByAntibodyAndPathogen() {
 export function PathogenSeroprevalenceBoxPlot() {
   const state = useContext(ArboContext);
 
-  const rawData = state.filteredData;
+  const dataQuery = useArboData();
+  const rawData = state.filteredData?.length <= 0 && !state.dataFiltered ? dataQuery.data?.records : state.filteredData;
 
   const data: { pathogen: string; seroprevalence: number }[] = rawData.map(
     (d: any) => {

--- a/app/pathogen/arbovirus/analyze/nivo-vis.tsx
+++ b/app/pathogen/arbovirus/analyze/nivo-vis.tsx
@@ -143,8 +143,7 @@ export function CountOfStudiesStratifiedByAntibodyAndPathogen() {
     },
   };
 
-  const dataQuery = useArboData();
-  const rawData = state.filteredData?.length > 0 ? state.filteredData : dataQuery.data?.records;
+  const rawData = state.filteredData;
 
   rawData?.forEach((d: any) => {
     const antibodies = d.antibodies as (keyof typeof data)[];
@@ -235,8 +234,7 @@ export function CountOfStudiesStratifiedByAntibodyAndPathogen() {
 export function PathogenSeroprevalenceBoxPlot() {
   const state = useContext(ArboContext);
 
-  const dataQuery = useArboData();
-  const rawData = state.filteredData?.length > 0 ? state.filteredData : dataQuery.data?.records;
+  const rawData = state.filteredData;
 
   const data: { pathogen: string; seroprevalence: number }[] = rawData.map(
     (d: any) => {

--- a/app/pathogen/arbovirus/dashboard/(map)/MapAndFilters.tsx
+++ b/app/pathogen/arbovirus/dashboard/(map)/MapAndFilters.tsx
@@ -119,7 +119,7 @@ export default function MapAndFilters() {
           <Card className={"absolute top-1 left-1 p-2"}>
             <CardContent className={"flex w-fit p-0"}>
               <ScrollText />
-              <p className={"ml-1 font-medium"}>{state.filteredData?.length > 0 ? state.filteredData.length : dataQuery.data.records.length}</p>
+              <p className={"ml-1 font-medium"}>{state.filteredData.length}</p>
             </CardContent>
           </Card>
         </Card>

--- a/app/pathogen/sarscov2/analyze/SarsCov2DataTable.tsx
+++ b/app/pathogen/sarscov2/analyze/SarsCov2DataTable.tsx
@@ -10,7 +10,7 @@ export default function SarsCov2DataTable() {
   const dataQuery = useSarsCov2Data();
   const state = useContext(SarsCov2Context);
   if(state.filteredData.length > 0 || (dataQuery.isSuccess && dataQuery.data)) {
-    return <DataTable columns={columns} data={state.filteredData?.length > 0 ? state.filteredData : dataQuery.data.records} />;
+    return <DataTable columns={columns} data={state.filteredData} />;
   } else {
     return <>Loading Data ...</>
   }

--- a/app/pathogen/sarscov2/dashboard/(map)/MapAndFilters.tsx
+++ b/app/pathogen/sarscov2/dashboard/(map)/MapAndFilters.tsx
@@ -59,7 +59,7 @@ export default function MapAndFilters() {
           <Card className={"absolute top-1 left-1 p-2"}>
             <CardContent className={"flex w-fit p-0"}>
               <ScrollText />
-              <p className={"ml-1 font-medium"}>{state.filteredData?.length > 0 ? state.filteredData.length : dataQuery.data.records.length}</p>
+              <p className={"ml-1 font-medium"}>{state.filteredData.length}</p>
             </CardContent>
           </Card>
         </Card>

--- a/components/customs/header.tsx
+++ b/components/customs/header.tsx
@@ -61,7 +61,7 @@ export const Header = () => {
   return (
     <header className="bg-background flex items-center justify-between h-12 w-screen px-2">
       <div className="cursor-pointer py-5 pl-2">
-        <Link href={"Explore"} className="flex items-center">
+        <Link href={"/"} className="flex items-center">
           <Image
             src={"/SerotrackerLogo.svg"}
             alt={"Serotracker Logo"}

--- a/components/customs/multi-select.tsx
+++ b/components/customs/multi-select.tsx
@@ -73,7 +73,7 @@ export function MultiSelect(props: MultiSelectProps) {
         className="overflow-visible bg-transparent"
       >
         <div className="group border border-input px-3 py-2 text-sm ring-offset-background rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
-          <div className="flex gap-1 flex-wrap">
+          <div className="flex flex-col gap-1 flex-wrap">
             {/* Avoid having the "Search" Icon */}
             {selectables.length > 0 && <CommandPrimitive.Input
                 ref={inputRef}
@@ -84,7 +84,8 @@ export function MultiSelect(props: MultiSelectProps) {
                 placeholder={heading}
                 className="bg-transparent outline-none placeholder:text-muted-foreground flex-1 inline pb-1 mb-1 border-b-2"
               />}
-            {createMultiSelectOptionList(selected).map((selectedOption) => {
+              <div className="flex gap-1 flex-wrap">
+              {createMultiSelectOptionList(selected).map((selectedOption) => {
               return (
                 <Badge className="rounded-sm bg-background hover:bg-backgroundHover p-1" key={selectedOption.value}>
                   {selectedOption.label}
@@ -106,6 +107,8 @@ export function MultiSelect(props: MultiSelectProps) {
                 </Badge>
               );
             })}
+              </div>
+
           </div>
         </div>
         <div className="relative mt-2">

--- a/components/customs/multi-select.tsx
+++ b/components/customs/multi-select.tsx
@@ -68,21 +68,28 @@ export function MultiSelect(props: MultiSelectProps) {
 
   return (
     <>
-      {selected.length > 0 && (
-        <p className={"mb-1 font-light text-sm"}>{heading}</p>
-      )}
       <Command
         onKeyDown={handleKeyDown}
         className="overflow-visible bg-transparent"
       >
         <div className="group border border-input px-3 py-2 text-sm ring-offset-background rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
           <div className="flex gap-1 flex-wrap">
+            {/* Avoid having the "Search" Icon */}
+            {selectables.length > 0 && <CommandPrimitive.Input
+                ref={inputRef}
+                value={inputValue}
+                onValueChange={setInputValue}
+                onBlur={() => setOpen(false)}
+                onFocus={() => setOpen(true)}
+                placeholder={heading}
+                className="bg-transparent outline-none placeholder:text-muted-foreground flex-1 inline pb-1 mb-1 border-b-2"
+              />}
             {createMultiSelectOptionList(selected).map((selectedOption) => {
               return (
-                <Badge key={selectedOption.value}>
+                <Badge className="rounded-sm bg-background hover:bg-backgroundHover p-1" key={selectedOption.value}>
                   {selectedOption.label}
                   <button
-                    className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                    className="ml-1 ring-offset-background outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
                         handleUnselect(selectedOption);
@@ -94,21 +101,11 @@ export function MultiSelect(props: MultiSelectProps) {
                     }}
                     onClick={() => handleUnselect(selectedOption)}
                   >
-                    <X className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                    <X className="h-3 w-3 text-foreground hover:bg-background" />
                   </button>
                 </Badge>
               );
             })}
-            {/* Avoid having the "Search" Icon */}
-            <CommandPrimitive.Input
-              ref={inputRef}
-              value={inputValue}
-              onValueChange={setInputValue}
-              onBlur={() => setOpen(false)}
-              onFocus={() => setOpen(true)}
-              placeholder={selected.length > 0 ? "" : heading}
-              className="ml-2 bg-transparent outline-none placeholder:text-muted-foreground flex-1"
-            />
           </div>
         </div>
         <div className="relative mt-2">

--- a/contexts/arbo-context.tsx
+++ b/contexts/arbo-context.tsx
@@ -43,7 +43,17 @@ function filterData(data: any[], filters: { [key: string]: string[] }): any[] {
   return data.filter((item: any) => {
     return filterKeys.every((key: string) => {
       if (!filters[key].length) return true;
-      return filters[key].includes(item[key]);
+      if(key === "antibody") {
+        return item["antibodies"].some((element: string) => filters[key].includes(element));
+      } else {
+        if (Array.isArray(item[key])) {
+          // If item[key] is an array, check if any element of item[key] is included in filters[key]
+          return item[key].some((element: string) => filters[key].includes(element));
+        } else {
+          // If item[key] is a string, check if it's included in filters[key]
+          return filters[key].includes(item[key]);
+        }
+      }
     });
   });
 }
@@ -57,9 +67,15 @@ export function setMapboxFilters(
   Object.keys(filters).forEach((filter: string) => {
     const keyFilters: any = [];
     if (filters[filter].length > 0) {
-      filters[filter].forEach((filterValue: string) => {
-        keyFilters.push(["in", filterValue, ["get", filter]]);
-      });
+      if(filter === "antibody") {
+        filters["antibody"].forEach((antibody: string) => {
+          keyFilters.push([">", ["index-of", antibody, ["get", "antibody"]], -1]);
+        });
+      } else {
+        filters[filter].forEach((filterValue: string) => {
+          keyFilters.push(["in", filterValue, ["get", filter]]);
+        });
+      }
     }
     if (keyFilters.length > 0) mapboxFilters.push(["any", ...keyFilters]);
   });

--- a/contexts/arbo-context.tsx
+++ b/contexts/arbo-context.tsx
@@ -21,6 +21,7 @@ export interface ArboContextType extends ArboStateType {
 interface ArboStateType {
   filteredData: any[];
   selectedFilters: { [key: string]: string[] };
+  dataFiltered: boolean;
 }
 interface ArboAction {
   type: ArboActionType;
@@ -36,6 +37,7 @@ export const initialState: ArboStateType = {
   selectedFilters: {
     ["pathogen"]: ["DENV", "ZIKV", "CHIKV", "YF", "WNV", "MAYV"],
   },
+  dataFiltered: false,
 };
 
 function filterData(data: any[], filters: { [key: string]: string[] }): any[] {
@@ -102,6 +104,7 @@ export const arboReducer = (state: ArboStateType, action: ArboAction) => {
         ...state,
         filteredData: filterData(action.payload.data, selectedFilters),
         selectedFilters: selectedFilters,
+        dataFiltered: true
       };
 
     default:

--- a/hooks/useMap.ts
+++ b/hooks/useMap.ts
@@ -16,6 +16,7 @@ function addArboDataLayers(map: mapboxgl.Map, data: any) {
   // Create mapbox source
   if(!map.getSource("arboStudyPins")){
     const arboStudyPins = data.map((record: any) => {
+      console.log(record.antibodies)
       return {
         type: "Feature",
         geometry: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,12 @@ module.exports = {
         'full-screen': 'calc(100vh - 6rem)',
       },
       colors: {
+        denv: "#FFADAD",
+        zikv: "#A0C4FF",
+        chikv: "#9BF6FF",
+        wnv: "#CAFFBF",
+        yf: "#FFD6A5",
+        mayv: "#FDFFB6",
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,7 @@ module.exports = {
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
+        backgroundHover: "hsl(var(--background-hover))",
         foreground: "hsl(var(--foreground))",
         primary: {
           DEFAULT: "hsl(var(--primary))",


### PR DESCRIPTION
This PR resolves: #33 #29 #32 and then some based on cosmetic things I believe could be improved

- Added a Link button to the Arbotracker table that takes the user to the publication from which said estimate was extracted
- Updated the style of some parts of the table so that it is easier to understand the data and the decimals are not super long
- Updated the logo to link to the landing page
- Improved the styling of the filters to look cleaner and work more intuitively
- Fixed the issue with the data resetting to all data when the filtered data was empty (this was not intuitive and so now the map and visualizations are blank when the filters amount to no data
- Fixed the antibody filter such that it now works for both the map and the data table and successfully filters for antibodies. 

