### PR TITLE
Changed instances of "Pathogen/Pathogens" to "Arbovirus/Arboviruses"

### DIFF
--- a/app/pathogen/arbovirus/analyze/columns.tsx
+++ b/app/pathogen/arbovirus/analyze/columns.tsx
@@ -60,7 +60,7 @@ export const columns: ColumnDef<Estimate>[] = [
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
         >
-          Pathogen
+          Arbovirus
           <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
       );

--- a/app/pathogen/arbovirus/dashboard/(map)/MapAndFilters.tsx
+++ b/app/pathogen/arbovirus/dashboard/(map)/MapAndFilters.tsx
@@ -110,7 +110,7 @@ export default function MapAndFilters() {
           </div>
           <Card className={"absolute bottom-1 right-1 "}>
             <CardHeader className={"py-3"}>
-              <p>Pathogens</p>
+              <p>Arboviruses</p>
             </CardHeader>
             <CardContent className={"flex justify-center flex-col"}>
               {filters.isSuccess &&

--- a/app/pathogen/arbovirus/dashboard/ArboStudyPopupContent.tsx
+++ b/app/pathogen/arbovirus/dashboard/ArboStudyPopupContent.tsx
@@ -20,7 +20,7 @@ function row(
 
 function pathogenTag(pathogen: string) {
   return (
-    <div className={"text-center w-full bg-gray-200"}>Pathogen: {pathogen}</div>
+    <div className={"text-center w-full bg-gray-200"}>Arbovirus: {pathogen}</div>
   );
 }
 

--- a/app/pathogen/arbovirus/dashboard/filters.tsx
+++ b/app/pathogen/arbovirus/dashboard/filters.tsx
@@ -111,7 +111,7 @@ export default function Filters({ excludedFields = [] }: FiltersProps) {
     [FilterableField.producer]: "Assay Producer",
     [FilterableField.sample_frame]: "Sample Frame",
     [FilterableField.antibody]: "Antibody",
-    [FilterableField.pathogen]: "Pathogen",
+    [FilterableField.pathogen]: "Arbovirus",
   };
   const demographicFilters = [
     FilterableField.age_group,

--- a/app/pathogen/sarscov2/analyze/columns.tsx
+++ b/app/pathogen/sarscov2/analyze/columns.tsx
@@ -44,7 +44,7 @@ export const columns: ColumnDef<Estimate>[] = [
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
         >
-          Pathogen
+          Arbovirus
           <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
       );


### PR DESCRIPTION
Resolves #53

I didn't bother with the plots since we're going to change those before showing the conference. The name of the property is still `pathogen` in the app, I'm just changing what it's displayed as. If we want to change the name of the property too on like the API and the rest of the front end (I'm not sure if there's a huge amount of value in that though), let's make it a tech debt ticket. I know there's new instances in PRs open right now so I'll probably just make suggestions on their PRs to use the right word as soon as this gets merged. If their stuff gets merged before mine, I'll change it myself.

![AAAAAAA](https://github.com/PathoTracker/Pathotracker/assets/86806388/99237181-a08b-46b7-8579-47445e1a8b64)
![BBBBBBBB](https://github.com/PathoTracker/Pathotracker/assets/86806388/4fb64b5a-2599-4170-9fb8-a81ac098bd77)
![CCCCCCC](https://github.com/PathoTracker/Pathotracker/assets/86806388/dbb79477-533f-4e80-9ffe-06680741e130)
