### PR TITLE
The Column selection dropdown no longer closes after selecting a column.

### DIFF
--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -124,11 +124,12 @@ export function DataTable<TData, TValue>({
                 return (
                   <DropdownMenuCheckboxItem
                     key={column.id}
-                    className="capitalize"
+                    className="capitalize cursor-pointer"
                     checked={column.getIsVisible()}
-                    onCheckedChange={(value: boolean) =>
-                      column.toggleVisibility(!!value)
-                    }
+                    onClick={(e) => {
+                      column.toggleVisibility()
+                      e.preventDefault()
+                    }}
                   >
                     {column.id}
                   </DropdownMenuCheckboxItem>


### PR DESCRIPTION
Resolves https://github.com/PathoTracker/Pathotracker/issues/59

![Peek 2023-12-19 12-02](https://github.com/PathoTracker/Pathotracker/assets/86806388/75d1c2fd-fd3b-48ad-adc7-6bf808240860)
