### PR TITLE
Fix bug that causes the modal not to open when `antibodies` is an empty array for the estimate.

### DIFF
--- a/app/pathogen/arbovirus/dashboard/ArboStudyPopupContent.tsx
+++ b/app/pathogen/arbovirus/dashboard/ArboStudyPopupContent.tsx
@@ -83,6 +83,8 @@ interface ArboStudyPopupContentProps {
 }
 
 export function ArboStudyPopupContent({ record }: ArboStudyPopupContentProps) {
+  const antibodiesArray = Array.isArray(record.antibodies) ? record.antibodies : [];
+
   return (
     <div className="w-[460px] bg-white pt-2">
       {/*Header section*/}
@@ -125,7 +127,7 @@ export function ArboStudyPopupContent({ record }: ArboStudyPopupContentProps) {
             Antibody Target
           </div>
           <div className={"w-2/3"}>
-            {record.antibodies.map((antibody: any, index: number) => (
+            {antibodiesArray.map((antibody: any, index: number) => (
           <span key={index} className={`${getAntiBodyColor(antibody)} mr-1 p-2 rounded-sm`}>
             {antibody}
           </span>


### PR DESCRIPTION
There is a small bug that came along with switching to the new API I believe where clicking on a record with an empty array for `antibodies` throws because for some reason an empty array is represented as `"[]"` instead of `[]`. This PR is just a quick band-aid to fix this, I'll look into something more permanent.