### PR TITLE
Freezes the `estimateId` column on the analysis tab

### DIFF
--- a/app/pathogen/arbovirus/analyze/ArboDataTable.tsx
+++ b/app/pathogen/arbovirus/analyze/ArboDataTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { columns } from "@/app/pathogen/arbovirus/analyze/columns";
-import { DataTable } from "@/components/ui/data-table";
+import { DataTable } from "@/components/ui/data-table/data-table";
 import React, { useContext } from "react";
 import { ArboContext } from "@/contexts/arbo-context";
 

--- a/app/pathogen/arbovirus/analyze/columns.tsx
+++ b/app/pathogen/arbovirus/analyze/columns.tsx
@@ -52,7 +52,14 @@ const get_header = (columnName: string) => {
   return HeaderComponent;
 };
 
-export const columns: ColumnDef<Estimate>[] = [
+enum DataTableFixedColumnSide {
+  LEFT = "LEFT",
+  RIGHT = "RIGHT",
+}
+
+export type DataTableColumnDef<TData, TValue> = ColumnDef<TData, TValue> & {fixed? : boolean};
+
+export const columns: DataTableColumnDef<Estimate, unknown>[] = [
   {
     accessorKey: "estimateId",
     header: get_header("Estimate ID"),
@@ -71,6 +78,7 @@ export const columns: ColumnDef<Estimate>[] = [
       return <p> {row.getValue("estimateId")} </p>
       
     },
+    fixed: true
   },
   {
     accessorKey: "pathogen",

--- a/app/pathogen/arbovirus/analyze/columns.tsx
+++ b/app/pathogen/arbovirus/analyze/columns.tsx
@@ -8,6 +8,7 @@ import { HeaderContext, Row } from "@tanstack/react-table";
 import validator from "validator";
 import Link from "next/link";
 import { TranslateDate } from "@/utils/translate-util/translate-service";
+import { DataTableColumnDef } from "@/components/ui/data-table/data-table";
 
 export type Estimate = {
   ageGroup: string;
@@ -51,8 +52,6 @@ const get_header = (columnName: string) => {
   );
   return HeaderComponent;
 };
-
-export type DataTableColumnDef<TData, TValue> = ColumnDef<TData, TValue> & {fixed? : boolean};
 
 export const columns: DataTableColumnDef<Estimate, unknown>[] = [
   {

--- a/app/pathogen/arbovirus/analyze/columns.tsx
+++ b/app/pathogen/arbovirus/analyze/columns.tsx
@@ -52,11 +52,6 @@ const get_header = (columnName: string) => {
   return HeaderComponent;
 };
 
-enum DataTableFixedColumnSide {
-  LEFT = "LEFT",
-  RIGHT = "RIGHT",
-}
-
 export type DataTableColumnDef<TData, TValue> = ColumnDef<TData, TValue> & {fixed? : boolean};
 
 export const columns: DataTableColumnDef<Estimate, unknown>[] = [

--- a/app/pathogen/sarscov2/analyze/SarsCov2DataTable.tsx
+++ b/app/pathogen/sarscov2/analyze/SarsCov2DataTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { columns } from "@/app/pathogen/sarscov2/analyze/columns";
-import { DataTable } from "@/components/ui/data-table";
+import { DataTable } from "@/components/ui/data-table/data-table";
 import React, { useContext } from "react";
 import { SarsCov2Context } from "@/contexts/sarscov2-context";
 import useSarsCov2Data from "@/hooks/useSarsCov2Data";

--- a/app/pathogen/sarscov2/analyze/columns.tsx
+++ b/app/pathogen/sarscov2/analyze/columns.tsx
@@ -4,6 +4,7 @@ import { ColumnDef } from "@tanstack/table-core";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowUpDown } from "lucide-react";
+import { DataTableColumnDef } from "@/components/ui/data-table/data-table";
 
 export type Estimate = {
   age_group: string;
@@ -35,7 +36,7 @@ export type Estimate = {
   url: string;
 };
 
-export const columns: ColumnDef<Estimate>[] = [
+export const columns: DataTableColumnDef<Estimate, unknown>[] = [
   {
     accessorKey: "pathogen",
     header: ({ column }) => {

--- a/components/ui/card-collection/card-collection.tsx
+++ b/components/ui/card-collection/card-collection.tsx
@@ -77,26 +77,30 @@ export const CardCollection = ({
               children: React.ReactNode;
             }) => React.ReactNode;
           } = {
-            [CardStyle.CARD]: ({ props, children }) => (
-              <Card
-                key={props.key}
-                className={props.className}
-                style={props.style}
-                hidden={props.hidden}
-              >
-                {children}
-              </Card>
-            ),
-            [CardStyle.DIV]: ({ props, children }) => (
-              <div 
-                key={props.key}
-                className={props.className}
-                style={props.style}
-                hidden={props.hidden}
-              >
-                {children}
-              </div>
-            ),
+            [CardStyle.CARD]: ({ props, children }) => {
+              const { key, ...propsWithoutKey } = props;
+
+              return (
+                <Card
+                  key={props.key}
+                  {...propsWithoutKey}
+                >
+                  {children}
+                </Card>
+              );
+            },
+            [CardStyle.DIV]: ({ props, children }) => {
+              const { key, ...propsWithoutKey } = props;
+
+              return (
+                <div
+                  key={props.key}
+                  {...propsWithoutKey}
+                >
+                  {children}
+                </div>
+              );
+            },
           };
 
           return styleToContainerMap[card.cardStyle]({

--- a/components/ui/card-collection/card-collection.tsx
+++ b/components/ui/card-collection/card-collection.tsx
@@ -78,10 +78,24 @@ export const CardCollection = ({
             }) => React.ReactNode;
           } = {
             [CardStyle.CARD]: ({ props, children }) => (
-              <Card {...props}> {children} </Card>
+              <Card
+                key={props.key}
+                className={props.className}
+                style={props.style}
+                hidden={props.hidden}
+              >
+                {children}
+              </Card>
             ),
             [CardStyle.DIV]: ({ props, children }) => (
-              <div {...props}> {children} </div>
+              <div 
+                key={props.key}
+                className={props.className}
+                style={props.style}
+                hidden={props.hidden}
+              >
+                {children}
+              </div>
             ),
           };
 

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -142,13 +142,15 @@ export function DataTable<TData, TValue>({
         </DropdownMenu>
       </div>
       <div className="rounded-md border">
-        <Table>
+        <Table className="border-separate">
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
+                  const className = header.column.id === 'estimateId' ? 'sticky left-0 border-b bg-white' : 'border-b bg-white';
+
                   return (
-                    <TableHead key={header.id}>
+                    <TableHead key={header.id} className={className}>
                       {header.isPlaceholder
                         ? null
                         : flexRender(
@@ -168,14 +170,18 @@ export function DataTable<TData, TValue>({
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
                 >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </TableCell>
-                  ))}
+                  {row.getVisibleCells().map((cell) => {
+                    const className = cell.column.id === 'estimateId' ? 'sticky left-0 border-b bg-white' : 'border-b bg-white';
+
+                    return (
+                      <TableCell key={cell.id} className={className}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    )
+                  })}
                 </TableRow>
               ))
             ) : (

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -142,12 +142,12 @@ export function DataTable<TData, TValue>({
         </DropdownMenu>
       </div>
       <div className="rounded-md border">
-        <Table className="border-separate">
+        <Table className="border-separate border-spacing-0">
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
-                  const className = header.column.id === 'estimateId' ? 'sticky left-0 border-b bg-white' : 'border-b bg-white';
+                  const className = header.column.id === 'estimateId' ? 'sticky left-0 border-b border-r bg-white' : 'border-b bg-white';
 
                   return (
                     <TableHead key={header.id} className={className}>
@@ -171,7 +171,7 @@ export function DataTable<TData, TValue>({
                   data-state={row.getIsSelected() && "selected"}
                 >
                   {row.getVisibleCells().map((cell) => {
-                    const className = cell.column.id === 'estimateId' ? 'sticky left-0 border-b bg-white' : 'border-b bg-white';
+                    const className = cell.column.id === 'estimateId' ? 'sticky left-0 border-b border-r bg-white group-hover:bg-zinc-100' : 'border-b bg-white group-hover:bg-zinc-100';
 
                     return (
                       <TableCell key={cell.id} className={className}>

--- a/components/ui/data-table/data-table.tsx
+++ b/components/ui/data-table/data-table.tsx
@@ -9,7 +9,7 @@ import {
   VisibilityState,
   getFilteredRowModel,
 } from "@tanstack/table-core";
-import { flexRender, useReactTable } from "@tanstack/react-table";
+import { ColumnDef, flexRender, useReactTable } from "@tanstack/react-table";
 import {
   Table,
   TableBody,
@@ -29,7 +29,10 @@ import {
 import { mkConfig, generateCsv, download } from "export-to-csv";
 import { useDataTableStyles } from "./use-data-table-styles";
 
-export type DataTableColumnDef<TData, TValue> = ColumnDef<TData, TValue> & {fixed? : boolean};
+export type DataTableColumnDef<TData, TValue> = ColumnDef<TData, TValue> & {
+  fixed?: boolean,
+  accessorKey: string,
+};
 
 interface DataTableProps<TData, TValue> {
   columns: DataTableColumnDef<TData, TValue>[];

--- a/components/ui/data-table/data-table.tsx
+++ b/components/ui/data-table/data-table.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ColumnDef,
   SortingState,
   getSortedRowModel,
   getCoreRowModel,
@@ -21,35 +20,37 @@ import {
 } from "@/components/ui/table";
 import React from "react";
 import { Button } from "@/components/ui/button";
-
-interface DataTableProps<TData, TValue> {
-  columns: ColumnDef<TData, TValue>[];
-  data: TData[];
-  expandFilters: () => void;
-  minimizeFilters: () => void;
-  areFiltersExpanded: boolean;
-}
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+} from "@/components/ui/dropdown-menu";
 import { mkConfig, generateCsv, download } from "export-to-csv";
+import { DataTableColumnDef } from "@/app/pathogen/arbovirus/analyze/columns";
+import { useDataTableStyles } from "./use-data-table-styles";
+
+interface DataTableProps<TData, TValue> {
+  columns: DataTableColumnDef<TData, TValue>[];
+  data: TData[];
+  expandFilters: () => void;
+  minimizeFilters: () => void;
+  areFiltersExpanded: boolean;
+}
 
 export function DataTable<TData, TValue>({
   columns,
   data,
   expandFilters,
   minimizeFilters,
-  areFiltersExpanded
+  areFiltersExpanded,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
     []
   );
   const [columnVisibility, setColumnVisibility] =
-    React.useState<VisibilityState>({})
+    React.useState<VisibilityState>({});
 
   const table = useReactTable({
     data,
@@ -68,29 +69,40 @@ export function DataTable<TData, TValue>({
     },
   });
 
+  const { generateClassnameForCell, generateClassnameForHeader } =
+    useDataTableStyles<TData, TValue>({ columns });
+
   const getAllVisibleData = () => {
     // Get the columns we want in the csv
-    let visibleColumns = table.getAllColumns().filter(column => column.getIsVisible())
-    let column_keys: string[] = visibleColumns.map(column => {return column.id})
-    const newArrayWithSubsetAttributes: Record<string, any>[] = table.getFilteredRowModel().rows.map((originalObject: any) => {
-      const newObj: Record<string, any> = {};
-      column_keys.forEach((attribute) => {
-        let temp_data = originalObject["original"][attribute];
-        if (Array.isArray(temp_data)) {
-          temp_data = temp_data.join(";")
-        }
-        newObj[attribute] = temp_data
-      });
-      return newObj;
+    let visibleColumns = table
+      .getAllColumns()
+      .filter((column) => column.getIsVisible());
+    let column_keys: string[] = visibleColumns.map((column) => {
+      return column.id;
     });
-    // TODO: FIX THIS FILENAME 
-    const csvConfig = mkConfig({ useKeysAsHeaders: true, filename: "arbotracker_dataset" });
-    let csv = generateCsv(csvConfig)(newArrayWithSubsetAttributes)
-    download(csvConfig)(csv)
-  }
+    const newArrayWithSubsetAttributes: Record<string, any>[] = table
+      .getFilteredRowModel()
+      .rows.map((originalObject: any) => {
+        const newObj: Record<string, any> = {};
+        column_keys.forEach((attribute) => {
+          let temp_data = originalObject["original"][attribute];
+          if (Array.isArray(temp_data)) {
+            temp_data = temp_data.join(";");
+          }
+          newObj[attribute] = temp_data;
+        });
+        return newObj;
+      });
+    // TODO: FIX THIS FILENAME
+    const csvConfig = mkConfig({
+      useKeysAsHeaders: true,
+      filename: "arbotracker_dataset",
+    });
+    let csv = generateCsv(csvConfig)(newArrayWithSubsetAttributes);
+    download(csvConfig)(csv);
+  };
 
   const setAllColumnVisibility = (visibility: boolean) => {
-
     // Iterate through all columns and toggle visibility based on selectAll state
     table.getAllColumns().forEach((column) => {
       if (column.getCanHide()) {
@@ -99,18 +111,34 @@ export function DataTable<TData, TValue>({
     });
   };
 
-  const handleSelectAll = () => {setAllColumnVisibility(true)}
-  const handleClearAll = () => {setAllColumnVisibility(false)}
+  const handleSelectAll = () => {
+    setAllColumnVisibility(true);
+  };
+  const handleClearAll = () => {
+    setAllColumnVisibility(false);
+  };
 
   return (
     <div>
       <div className="flex items-center justify-between py-4">
-        <h2><b>Explore arbovirus seroprevalence estimates in our database</b></h2>
+        <h2>
+          <b>Explore arbovirus seroprevalence estimates in our database</b>
+        </h2>
         <div className="flex">
-          <Button variant="outline" className="bg-foreground mx-2 whitespace-nowrap" onClick={() => areFiltersExpanded ? minimizeFilters() : expandFilters()}>
-            { areFiltersExpanded ? "Hide Filters" : "See Filters" }
+          <Button
+            variant="outline"
+            className="bg-foreground mx-2 whitespace-nowrap"
+            onClick={() =>
+              areFiltersExpanded ? minimizeFilters() : expandFilters()
+            }
+          >
+            {areFiltersExpanded ? "Hide Filters" : "See Filters"}
           </Button>
-          <Button variant="outline" className="bg-foreground mx-2 whitespace-nowrap" onClick={getAllVisibleData}>
+          <Button
+            variant="outline"
+            className="bg-foreground mx-2 whitespace-nowrap"
+            onClick={getAllVisibleData}
+          >
             Download CSV
           </Button>
           <DropdownMenu>
@@ -120,17 +148,23 @@ export function DataTable<TData, TValue>({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="bg-foreground">
-              <Button variant="outline" className="ml-auto bg-white" onClick={handleSelectAll}>
-                  Select All
+              <Button
+                variant="outline"
+                className="ml-auto bg-white"
+                onClick={handleSelectAll}
+              >
+                Select All
               </Button>
-              <Button variant="outline" className="ml-auto bg-white" onClick={handleClearAll}>
-                  Clear All
+              <Button
+                variant="outline"
+                className="ml-auto bg-white"
+                onClick={handleClearAll}
+              >
+                Clear All
               </Button>
               {table
                 .getAllColumns()
-                .filter(
-                  (column) => column.getCanHide()
-                )
+                .filter((column) => column.getCanHide())
                 .map((column) => {
                   return (
                     <DropdownMenuCheckboxItem
@@ -138,13 +172,13 @@ export function DataTable<TData, TValue>({
                       className="capitalize cursor-pointer"
                       checked={column.getIsVisible()}
                       onClick={(e) => {
-                        column.toggleVisibility()
-                        e.preventDefault()
+                        column.toggleVisibility();
+                        e.preventDefault();
                       }}
                     >
                       {column.id}
                     </DropdownMenuCheckboxItem>
-                  )
+                  );
                 })}
             </DropdownMenuContent>
           </DropdownMenu>
@@ -156,7 +190,7 @@ export function DataTable<TData, TValue>({
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
-                  const className = header.column.id === 'estimateId' ? 'sticky left-0 border-b border-r bg-white' : 'border-b bg-white';
+                  const className = generateClassnameForHeader({ columnId: header.column.id });
 
                   return (
                     <TableHead key={header.id} className={className}>
@@ -180,7 +214,7 @@ export function DataTable<TData, TValue>({
                   data-state={row.getIsSelected() && "selected"}
                 >
                   {row.getVisibleCells().map((cell) => {
-                    const className = cell.column.id === 'estimateId' ? 'sticky left-0 border-b border-r bg-white group-hover:bg-zinc-100' : 'border-b bg-white group-hover:bg-zinc-100';
+                    const className = generateClassnameForCell({ columnId: cell.column.id });
 
                     return (
                       <TableCell key={cell.id} className={className}>
@@ -189,7 +223,7 @@ export function DataTable<TData, TValue>({
                           cell.getContext()
                         )}
                       </TableCell>
-                    )
+                    );
                   })}
                 </TableRow>
               ))

--- a/components/ui/data-table/data-table.tsx
+++ b/components/ui/data-table/data-table.tsx
@@ -27,8 +27,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { mkConfig, generateCsv, download } from "export-to-csv";
-import { DataTableColumnDef } from "@/app/pathogen/arbovirus/analyze/columns";
 import { useDataTableStyles } from "./use-data-table-styles";
+
+export type DataTableColumnDef<TData, TValue> = ColumnDef<TData, TValue> & {fixed? : boolean};
 
 interface DataTableProps<TData, TValue> {
   columns: DataTableColumnDef<TData, TValue>[];
@@ -213,18 +214,14 @@ export function DataTable<TData, TValue>({
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
                 >
-                  {row.getVisibleCells().map((cell) => {
-                    const className = generateClassnameForCell({ columnId: cell.column.id });
-
-                    return (
-                      <TableCell key={cell.id} className={className}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
-                        )}
-                      </TableCell>
-                    );
-                  })}
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id} className={generateClassnameForCell({ columnId: cell.column.id })}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
                 </TableRow>
               ))
             ) : (

--- a/components/ui/data-table/use-data-table-styles.tsx
+++ b/components/ui/data-table/use-data-table-styles.tsx
@@ -21,7 +21,7 @@ export const useDataTableStyles = <TData, TValue>(input: useDataStylesInput<TDat
     const baseClassnameForHeader = "border-b bg-white";
     const classnameForLeftColumnFixation = "sticky left-0 border-r";
 
-    const columnDefinition = columns.find((column) => 'accessorKey' in column && column.accessorKey === columnId);
+    const columnDefinition = columns.find((column) => column.accessorKey === columnId);
 
     if (!columnDefinition || columnDefinition.fixed !== true) {
       return baseClassnameForHeader;
@@ -38,7 +38,7 @@ export const useDataTableStyles = <TData, TValue>(input: useDataStylesInput<TDat
     const baseClassnameForHeader = "border-b bg-white group-hover:bg-zinc-100";
     const classnameForLeftColumnFixation = "sticky left-0 border-r";
 
-    const columnDefinition = columns.find((column) => 'accessorKey' in column && column.accessorKey === columnId);
+    const columnDefinition = columns.find((column) => column.accessorKey === columnId);
 
     if (!columnDefinition || columnDefinition.fixed !== true) {
       return baseClassnameForHeader;

--- a/components/ui/data-table/use-data-table-styles.tsx
+++ b/components/ui/data-table/use-data-table-styles.tsx
@@ -1,0 +1,56 @@
+import { DataTableColumnDef } from "@/app/pathogen/arbovirus/analyze/columns";
+
+interface useDataStylesInput<TData, TValue> {
+  columns: DataTableColumnDef<TData, TValue>[];
+}
+
+interface GenerateClassnameForHeaderInput {
+  columnId: string;
+}
+
+interface GenerateClassnameForCellInput {
+  columnId: string;
+}
+
+export const useDataTableStyles = <TData, TValue>(input: useDataStylesInput<TData, TValue>) => {
+  const { columns } = input;
+
+  const generateClassnameForHeader = (input: GenerateClassnameForHeaderInput) => {
+    const { columnId } = input;
+
+    const baseClassnameForHeader = "border-b bg-white";
+    const classnameForLeftColumnFixation = "sticky left-0 border-r";
+
+    const columnDefinition = columns.find((column) => 'accessorKey' in column && column.accessorKey === columnId);
+
+    if (!columnDefinition || columnDefinition.fixed !== true) {
+      return baseClassnameForHeader;
+    }
+
+    return baseClassnameForHeader
+      .concat(" ")
+      .concat(classnameForLeftColumnFixation);
+  };
+
+  const generateClassnameForCell = (input: GenerateClassnameForCellInput) => {
+    const { columnId } = input;
+
+    const baseClassnameForHeader = "border-b bg-white group-hover:bg-zinc-100";
+    const classnameForLeftColumnFixation = "sticky left-0 border-r";
+
+    const columnDefinition = columns.find((column) => 'accessorKey' in column && column.accessorKey === columnId);
+
+    if (!columnDefinition || columnDefinition.fixed !== true) {
+      return baseClassnameForHeader;
+    }
+
+    return baseClassnameForHeader
+      .concat(" ")
+      .concat(classnameForLeftColumnFixation);
+  };
+
+  return {
+    generateClassnameForHeader,
+    generateClassnameForCell
+  };
+};

--- a/components/ui/data-table/use-data-table-styles.tsx
+++ b/components/ui/data-table/use-data-table-styles.tsx
@@ -1,4 +1,4 @@
-import { DataTableColumnDef } from "@/app/pathogen/arbovirus/analyze/columns";
+import { DataTableColumnDef } from "./data-table";
 
 interface useDataStylesInput<TData, TValue> {
   columns: DataTableColumnDef<TData, TValue>[];

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -55,7 +55,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "transition-colors hover:bg-zinc-100/50 data-[state=selected]:bg-zinc-100 dark:hover:bg-zinc-800/50 dark:data-[state=selected]:bg-zinc-800",
+      "transition-colors group hover:bg-zinc-100/50 data-[state=selected]:bg-zinc-100 dark:hover:bg-zinc-800/50 dark:data-[state=selected]:bg-zinc-800",
       className
     )}
     {...props}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -84,7 +84,7 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:mr-0", className)}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
     {...props}
   />
 ))

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -55,7 +55,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "border-b transition-colors hover:bg-zinc-100/50 data-[state=selected]:bg-zinc-100 dark:hover:bg-zinc-800/50 dark:data-[state=selected]:bg-zinc-800",
+      "transition-colors hover:bg-zinc-100/50 data-[state=selected]:bg-zinc-100 dark:hover:bg-zinc-800/50 dark:data-[state=selected]:bg-zinc-800",
       className
     )}
     {...props}
@@ -84,7 +84,7 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:mr-0", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
Resolves #102 and freezes the `estimateId` column to the left of the table on the analysis tab.

![Peek 2024-01-06 14-27](https://github.com/PathoTracker/Pathotracker/assets/86806388/f3a69f9b-af16-4968-84f5-43fb232e9292)
