### PR TITLE
Added the filters sidebar to the redesigned dashboard + analyze page

### DIFF
--- a/app/pathogen/arbovirus/analyze/page.tsx
+++ b/app/pathogen/arbovirus/analyze/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import Filters from "@/app/pathogen/arbovirus/dashboard/filters";
+import { Filters } from "@/app/pathogen/arbovirus/dashboard/filters";
 import ArboDataTable from "@/app/pathogen/arbovirus/analyze/ArboDataTable";
 import clsx from "clsx";
 import { CardConfiguration, CardStyle, CardType, getConfigurationForCard } from "@/components/ui/card-collection/card-collection-types";

--- a/app/pathogen/arbovirus/dashboard/filters.tsx
+++ b/app/pathogen/arbovirus/dashboard/filters.tsx
@@ -167,9 +167,12 @@ const FilterSection = ({
 
 interface FiltersProps {
   excludedFields?: FilterableField[];
+  className?: string;
 }
 
-export default function Filters({ excludedFields = [] }: FiltersProps) {
+export function Filters(props: FiltersProps) {
+  const excludedFields = props.excludedFields ?? [];
+
   const state = useContext(ArboContext);
   const demographicFilters = [
     {field: FilterableField.ageGroup, label: "Age Group", valueToLabelMap: {}},
@@ -228,7 +231,7 @@ export default function Filters({ excludedFields = [] }: FiltersProps) {
 
   if (filterData) {
     return (
-      <div>
+      <div className={props.className}>
         <FilterSection
           headerText="Demographic"
           headerTooltipText="Filter on demographic variables, including population group, sex, and age group."

--- a/app/pathogen/arbovirus/dashboard/page.tsx
+++ b/app/pathogen/arbovirus/dashboard/page.tsx
@@ -5,7 +5,7 @@ import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { ArbovirusMap } from "@/app/pathogen/arbovirus/dashboard/(map)/ArbovirusMap";
 import { MedianSeroPrevByWHOregion } from "../analyze/recharts";
-import Filters, { FilterableField } from "./filters";
+import { FilterableField, Filters } from "./filters";
 import { CardConfiguration, CardStyle, CardType, getConfigurationForCard } from "@/components/ui/card-collection/card-collection-types";
 import { CardCollection } from "@/components/ui/card-collection/card-collection";
 import { useMap } from "react-map-gl";

--- a/app/pathogen/arbovirus/wip/page.tsx
+++ b/app/pathogen/arbovirus/wip/page.tsx
@@ -2,13 +2,13 @@
 import { useScrollSectionGroup } from "@/components/ui/scroll-section-group/use-scroll-section-group";
 import { notFound, useSearchParams } from "next/navigation";
 import React, { useEffect } from "react";
-import { redesignedArbovirusPageSections, sectionUrlParameterToSectionId } from "./sections";
-import { Filters } from "../dashboard/filters";
+import { RedesignedArbovirusPageSectionId, redesignedArbovirusPageSections, sectionUrlParameterToSectionId } from "./sections";
+import { FilterableField, Filters } from "../dashboard/filters";
 
 export default function RedesignedArbovirusPage() {
   const searchParams = useSearchParams();
 
-  const { renderScrollSectionGroup, moveScrollSectionGroupToSection } = useScrollSectionGroup({
+  const { renderScrollSectionGroup, moveScrollSectionGroupToSection, idOfCurrentlyViewedSection } = useScrollSectionGroup({
     scrollSectionGroupProps: {
       sections: redesignedArbovirusPageSections,
       className:"col-span-10 row-span-2",
@@ -32,7 +32,12 @@ export default function RedesignedArbovirusPage() {
   return (
     <div className="col-span-12 row-span-2 grid gap-0 grid-cols-12 grid-rows-2 grid-flow-col w-screen overflow-hidden border-box -my-4 -ml-4">
       <div className="overflow-y-scroll col-span-2 h-full row-span-2">
-        <Filters className="p-4 border-black border-r-2" />
+        <Filters
+          className="p-4 border-black border-r-2"
+          excludedFields={
+            idOfCurrentlyViewedSection === RedesignedArbovirusPageSectionId.MAP ? [FilterableField.pathogen] : [] 
+          }
+        />
       </div>
       {renderScrollSectionGroup()}
     </div>

--- a/app/pathogen/arbovirus/wip/page.tsx
+++ b/app/pathogen/arbovirus/wip/page.tsx
@@ -3,6 +3,7 @@ import { useScrollSectionGroup } from "@/components/ui/scroll-section-group/use-
 import { notFound, useSearchParams } from "next/navigation";
 import React, { useEffect } from "react";
 import { redesignedArbovirusPageSections, sectionUrlParameterToSectionId } from "./sections";
+import { Filters } from "../dashboard/filters";
 
 export default function RedesignedArbovirusPage() {
   const searchParams = useSearchParams();
@@ -30,8 +31,8 @@ export default function RedesignedArbovirusPage() {
   
   return (
     <div className="col-span-12 row-span-2 grid gap-0 grid-cols-12 grid-rows-2 grid-flow-col w-screen overflow-hidden border-box -my-4 -ml-4">
-      <div className="col-span-2 h-full row-span-2">
-        <div className="w-full h-full bg-orange-500"> placeholder for filters </div>
+      <div className="overflow-y-scroll col-span-2 h-full row-span-2">
+        <Filters className="p-4 border-black border-r-2" />
       </div>
       {renderScrollSectionGroup()}
     </div>

--- a/app/pathogen/arbovirus/wip/page.tsx
+++ b/app/pathogen/arbovirus/wip/page.tsx
@@ -31,9 +31,9 @@ export default function RedesignedArbovirusPage() {
   
   return (
     <div className="col-span-12 row-span-2 grid gap-0 grid-cols-12 grid-rows-2 grid-flow-col w-screen overflow-hidden border-box -my-4 -ml-4">
-      <div className="overflow-y-scroll col-span-2 h-full row-span-2">
+      <div className="overflow-y-scroll col-span-2 h-full row-span-2 border-black border-r-2">
         <Filters
-          className="p-4 border-black border-r-2"
+          className="p-4"
           excludedFields={
             idOfCurrentlyViewedSection === RedesignedArbovirusPageSectionId.MAP ? [FilterableField.pathogen] : [] 
           }

--- a/app/pathogen/arbovirus/wip/sections.tsx
+++ b/app/pathogen/arbovirus/wip/sections.tsx
@@ -1,6 +1,6 @@
 import { RefObject } from "react";
 
-enum RedesignedArbovirusPageSectionId {
+export enum RedesignedArbovirusPageSectionId {
   MAP = 'MAP',
   TABLE = 'TABLE',
   VISUALIZATIONS = 'VISUALIZATIONS'

--- a/app/pathogen/sarscov2/analyze/page.tsx
+++ b/app/pathogen/sarscov2/analyze/page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import Filters from "@/app/pathogen/sarscov2/dashboard/filters";
+import { Filters } from "@/app/pathogen/sarscov2/dashboard/filters";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import SarsCov2DataTable from "./SarsCov2DataTable";
 

--- a/app/pathogen/sarscov2/dashboard/(map)/MapAndFilters.tsx
+++ b/app/pathogen/sarscov2/dashboard/(map)/MapAndFilters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import Filters from "@/app/pathogen/sarscov2/dashboard/filters";
+import { Filters } from "@/app/pathogen/sarscov2/dashboard/filters";
 import React, { useContext } from "react";
 import { ScrollText } from "lucide-react";
 import useSarsCov2Data from "@/hooks/useSarsCov2Data";

--- a/app/pathogen/sarscov2/dashboard/filters.tsx
+++ b/app/pathogen/sarscov2/dashboard/filters.tsx
@@ -56,7 +56,7 @@ const buildFilterDropdown = (
   );
 };
 
-export default function Filters() {
+export function Filters() {
   const state = useContext(SarsCov2Context);
 
   const { data } = useSarsCov2Data();

--- a/components/ui/scroll-section-group/use-scroll-section-group.tsx
+++ b/components/ui/scroll-section-group/use-scroll-section-group.tsx
@@ -62,7 +62,7 @@ export const useScrollSectionGroup = <TSectionId extends string>(input: UseScrol
   
   const idOfCurrentlyViewedSection = useMemo(() => {
     return input.scrollSectionGroupProps.sections[currentIndex].id;
-  }, [currentIndex])
+  }, [currentIndex, input.scrollSectionGroupProps.sections])
 
   return {
     renderScrollSectionGroup,

--- a/components/ui/scroll-section-group/use-scroll-section-group.tsx
+++ b/components/ui/scroll-section-group/use-scroll-section-group.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, createRef } from "react";
+import { useCallback, useRef, useState, createRef, useMemo } from "react";
 import { ScrollSection, ScrollSectionGroup, ScrollSectionGroupProps } from "./scroll-section-group";
 
 interface MoveScrollSectionGroupToSectionInput<TSectionId extends string> {
@@ -14,6 +14,7 @@ interface UseScrollSectionGroupInput<TSectionId extends string> {
 interface UseScrollSectionGroupOutput<TSectionId extends string> {
   renderScrollSectionGroup: () => React.ReactNode;
   moveScrollSectionGroupToSection: (input: MoveScrollSectionGroupToSectionInput<TSectionId>) => void;
+  idOfCurrentlyViewedSection: TSectionId;
 }
 
 export const useScrollSectionGroup = <TSectionId extends string>(input: UseScrollSectionGroupInput<TSectionId>): UseScrollSectionGroupOutput<TSectionId> => {
@@ -58,9 +59,14 @@ export const useScrollSectionGroup = <TSectionId extends string>(input: UseScrol
       setLastScrollEventActionedUnixEpochTimestampMilliseconds(timeEventOccurredMilliseconds);
     }
   }, [input.scrollSectionGroupProps.sections, setCurrentIndex]);
+  
+  const idOfCurrentlyViewedSection = useMemo(() => {
+    return input.scrollSectionGroupProps.sections[currentIndex].id;
+  }, [currentIndex])
 
   return {
     renderScrollSectionGroup,
-    moveScrollSectionGroupToSection
+    moveScrollSectionGroupToSection,
+    idOfCurrentlyViewedSection
   }
 }


### PR DESCRIPTION
This PR is another PR of many that will implement https://github.com/PathoTracker/Pathotracker/issues/136.

Here, I'm just adding the filters sidebar to my new consolidated dashboard + analyze page tab.

![Peek 2024-01-21 17-14](https://github.com/PathoTracker/Pathotracker/assets/86806388/9aadf947-e5e3-40d2-9773-d11f7bab6e1d)
