### PR TITLE
Added the map to the redesigned dashboard + analyze page

### DIFF
--- a/app/pathogen/arbovirus/dashboard/(map)/ArbovirusMap.tsx
+++ b/app/pathogen/arbovirus/dashboard/(map)/ArbovirusMap.tsx
@@ -38,7 +38,6 @@ export const pathogenColors: { [key: string]: string } = {
 
 //TODO: SeanKennyNF remove this type, the typeguard, and all references to expanding and minimizing visualizations once the redesign is rolled out.
 interface OldArbovirusMapProps {
-  className?: string;
   areVisualizationsExpanded: boolean;
   expandVisualizations: () => void;
   minimizeVisualizations: () => void;

--- a/app/pathogen/arbovirus/dashboard/(map)/ArbovirusMap.tsx
+++ b/app/pathogen/arbovirus/dashboard/(map)/ArbovirusMap.tsx
@@ -36,14 +36,24 @@ export const pathogenColors: { [key: string]: string } = {
   MAYV: "#c5a3ff",
 };
 
-interface ArbovirusMapProps {
+//TODO: SeanKennyNF remove this type, the typeguard, and all references to expanding and minimizing visualizations once the redesign is rolled out.
+interface OldArbovirusMapProps {
+  className?: string;
   areVisualizationsExpanded: boolean;
   expandVisualizations: () => void;
   minimizeVisualizations: () => void;
 }
 
-export function ArbovirusMap(input: ArbovirusMapProps) {
-  const { expandVisualizations, minimizeVisualizations, areVisualizationsExpanded } = input;
+const isOldArbovirusMapProps = (props: ArbovirusMapProps): props is OldArbovirusMapProps =>
+  'areVisualizationsExpanded' in props && typeof props.areVisualizationsExpanded === 'boolean' &&
+  'expandVisualizations' in props && typeof props.expandVisualizations === 'function' &&
+  'minimizeVisualizations' in props && typeof props.minimizeVisualizations === 'function'
+
+type NewArbovirusMapProps = {}
+
+type ArbovirusMapProps = OldArbovirusMapProps | NewArbovirusMapProps;
+
+export function ArbovirusMap(props: ArbovirusMapProps) {
   const state = useContext(ArboContext);
   const [ isStudySubmissionPromptVisible, setStudySubmissionPromptVisibility ] = useState(true);
   const { data }  = useArboData();
@@ -119,10 +129,13 @@ export function ArbovirusMap(input: ArbovirusMapProps) {
             </p>
           </CardContent>
         </Card>
-        <MapExpandPlotsPrompt
-          text={areVisualizationsExpanded ? "Hide Figures" : "See Figures"}
-          onClick={areVisualizationsExpanded ? minimizeVisualizations : expandVisualizations}
-        />
+        {isOldArbovirusMapProps(props) && 
+          //TODO: SeanKennyNF remove the expand plots prompt when the website redesign is fully rolled out.
+          <MapExpandPlotsPrompt
+            text={props.areVisualizationsExpanded ? "Hide Figures" : "See Figures"}
+            onClick={props.areVisualizationsExpanded ? props.minimizeVisualizations : props.expandVisualizations}
+          />
+        }
       </div>
     </>
   );

--- a/app/pathogen/arbovirus/wip/sections.tsx
+++ b/app/pathogen/arbovirus/wip/sections.tsx
@@ -1,4 +1,5 @@
 import { RefObject } from "react";
+import { ArbovirusMap } from "../dashboard/(map)/ArbovirusMap";
 
 export enum RedesignedArbovirusPageSectionId {
   MAP = 'MAP',
@@ -22,9 +23,9 @@ export const redesignedArbovirusPageSections = [{
     <section
       key={input.key}
       ref={input.ref}
-      className="w-full h-[95%] bg-blue-500 snap-start snap-always scroll-smooth"
+      className="w-full h-[95%] snap-start snap-always scroll-smooth overflow-hidden relative row-span-2 border-black border-b-2"
     >
-      placeholder for map
+      <ArbovirusMap />
     </section>
   )
 }, {


### PR DESCRIPTION
This PR another PR of many that will implement https://github.com/PathoTracker/Pathotracker/issues/136.

Here, I'm just adding the map to my new consolidated dashboard + analyze page tab.

![Screenshot from 2024-01-21 17-44-57](https://github.com/PathoTracker/Pathotracker/assets/86806388/51bbf838-4c5a-47a8-a125-ac9e53748a54)

![Peek 2024-01-21 17-52](https://github.com/PathoTracker/Pathotracker/assets/86806388/1946b3f8-1ad2-48bf-9e61-740b32f647ee)

![Peek 2024-01-21 17-53](https://github.com/PathoTracker/Pathotracker/assets/86806388/d0b548c4-3d9b-4656-a5e1-c98bfa2e98c3)
