### PR TITLE
Added the table to the redesigned dashboard + analyze page

### DIFF
--- a/app/pathogen/arbovirus/analyze/ArboDataTable.tsx
+++ b/app/pathogen/arbovirus/analyze/ArboDataTable.tsx
@@ -5,17 +5,23 @@ import { DataTable } from "@/components/ui/data-table/data-table";
 import React, { useContext } from "react";
 import { ArboContext } from "@/contexts/arbo-context";
 
-interface ArboDataTableProps {
+//TODO: SeanKennyNF remove this type, the typeguard, and all references to expanding and minimizing visualizations once the redesign is rolled out.
+interface OldArboDataTableProps {
   expandFilters: () => void;
   minimizeFilters: () => void;
   areFiltersExpanded: boolean;
 }
 
-export default function ArboDataTable({
-  expandFilters,
-  minimizeFilters,
-  areFiltersExpanded,
-}: ArboDataTableProps) {
+const isOldArboDataTableProps = (props: ArboDataTableProps): props is OldArboDataTableProps =>
+  'areFiltersExpanded' in props && typeof props.areFiltersExpanded === 'boolean' &&
+  'expandFilters' in props && typeof props.expandFilters === 'function' &&
+  'minimizeFilters' in props && typeof props.minimizeFilters === 'function'
+
+interface NewArboDataTableProps {};
+
+type ArboDataTableProps = OldArboDataTableProps | NewArboDataTableProps;
+
+export const ArboDataTable = (props: ArboDataTableProps) => {
   const state = useContext(ArboContext);
 
   if (state.filteredData?.length > 0) {
@@ -23,9 +29,11 @@ export default function ArboDataTable({
       <DataTable
         columns={columns}
         data={state.filteredData}
-        expandFilters={expandFilters}
-        minimizeFilters={minimizeFilters}
-        areFiltersExpanded={areFiltersExpanded}
+        {...(isOldArboDataTableProps(props) ? {
+          areFiltersExpanded: props.areFiltersExpanded,
+          expandFilters: props.expandFilters,
+          minimizeFilters: props.minimizeFilters
+        } : {})}
       />
     );
   } else {

--- a/app/pathogen/arbovirus/analyze/page.tsx
+++ b/app/pathogen/arbovirus/analyze/page.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Filters } from "@/app/pathogen/arbovirus/dashboard/filters";
-import ArboDataTable from "@/app/pathogen/arbovirus/analyze/ArboDataTable";
+import { ArboDataTable } from "@/app/pathogen/arbovirus/analyze/ArboDataTable";
 import clsx from "clsx";
 import { CardConfiguration, CardStyle, CardType, getConfigurationForCard } from "@/components/ui/card-collection/card-collection-types";
 import { CardCollection } from "@/components/ui/card-collection/card-collection";

--- a/app/pathogen/arbovirus/wip/sections.tsx
+++ b/app/pathogen/arbovirus/wip/sections.tsx
@@ -35,7 +35,7 @@ export const redesignedArbovirusPageSections = [{
     <section
       key={input.key}
       ref={input.ref}
-      className="w-full h-[95%] snap-start snap-always scroll-smooth overflow-scroll"
+      className="w-full h-[95%] snap-start snap-always scroll-smooth overflow-scroll border-black border-b-2"
     >
       <ArboDataTable />
     </section>

--- a/app/pathogen/arbovirus/wip/sections.tsx
+++ b/app/pathogen/arbovirus/wip/sections.tsx
@@ -1,5 +1,6 @@
 import { RefObject } from "react";
 import { ArbovirusMap } from "../dashboard/(map)/ArbovirusMap";
+import { ArboDataTable } from "@/app/pathogen/arbovirus/analyze/ArboDataTable";
 
 export enum RedesignedArbovirusPageSectionId {
   MAP = 'MAP',
@@ -34,9 +35,9 @@ export const redesignedArbovirusPageSections = [{
     <section
       key={input.key}
       ref={input.ref}
-      className="w-full h-[95%] bg-yellow-500 snap-start snap-always scroll-smooth"
+      className="w-full h-[95%] snap-start snap-always scroll-smooth overflow-scroll"
     >
-      placeholder for table
+      <ArboDataTable />
     </section>
   )
 }, {


### PR DESCRIPTION
This PR another PR of many that will implement https://github.com/PathoTracker/Pathotracker/issues/136.

Here, I'm just adding the table to my new consolidated dashboard + analyze page tab.

![Peek 2024-01-27 11-23](https://github.com/PathoTracker/Pathotracker/assets/86806388/974399cc-9c35-41fa-b8b1-8883d1226704)

![Peek 2024-01-27 11-31](https://github.com/PathoTracker/Pathotracker/assets/86806388/65df35d9-e47b-4c57-8b6d-481b587433d1)